### PR TITLE
Make standard command line pip installable package

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ It is necessary to have **python3** and **pip3**
 ## Installation
 
 ```bash
-pip3 install -r requirements.txt
+pip3 install git+https://github.com/Juvenal-Yescas/mediafire-dl
 ```
 
 ## Usage
@@ -24,19 +24,19 @@ pip3 install -r requirements.txt
 ### From Command Line
 
 ```bash
-$ # python3 mediafire-dl.py mediafire_link_1 
+$ # mediafire-dl mediafire_link_1 
 
-$ # python3 mediafire-dl.py mediafire_link_1 mediafire_link_2 mediafire_link_3
+$ # mediafire-dl mediafire_link_1 mediafire_link_2 mediafire_link_3
 ```
 
 ### From Python
 
 ```python
-import mediafire-dl
+import mediafire_dl
 
 url = 'https://mediafire.com/xx/xx/file.zip'
 output = 'file.zip'
-mediafire-dl.download(url, output, quiet=False)
+mediafire_dl.download(url, output, quiet=False)
 ```
 ## Build with
 

--- a/mediafire_dl.py
+++ b/mediafire_dl.py
@@ -96,6 +96,10 @@ def download(url, output, quiet):
             pass
     return output
 
-if __name__ == "__main__":
+
+def main():
     for url in sys.argv[1:]:
-        download(url,output=None,quiet=False)
+        download(url, output=None, quiet=False)
+
+if __name__ == "__main__":
+    main()

--- a/mediafire_dl.py
+++ b/mediafire_dl.py
@@ -1,6 +1,7 @@
 #!/usr/bin/python3
 # -*- coding: utf-8 -*-
 
+import argparse
 import os
 import os.path as osp
 import re
@@ -98,8 +99,14 @@ def download(url, output, quiet):
 
 
 def main():
-    for url in sys.argv[1:]:
+    desc = 'Simple command-line script to download files from mediafire'
+    parser = argparse.ArgumentParser(description=desc)
+    parser.add_argument('url', nargs='+')
+    args = parser.parse_args()
+
+    for url in args.url:
         download(url, output=None, quiet=False)
+
 
 if __name__ == "__main__":
     main()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,0 @@
-requests
-tqdm

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,27 @@
+from setuptools import setup, find_packages
+
+setup(
+    name="mediafire-dl",
+    version="0.1.0",
+    description="Simple command-line script to download files from mediafire based on gdown",
+    url="https://github.com/Juvenal-Yescas/mediafire-dl",
+    author="Juvenal Yescas",
+    author_email="juvenal@mail.com",
+    classifiers=[
+        "Development Status :: 3 - Alpha",
+        "Intended Audience :: Developers",
+        "Programming Language :: Python :: 3",
+        "Programming Language :: Python :: 3.7"
+        "Programming Language :: Python :: 3.8",
+        "Programming Language :: Python :: 3.9",
+    ],
+    keywords="audo ai",
+    py_modules=['mediafire_dl'],
+    install_requires=[
+        "requests",
+        "tqdm",
+    ],
+    entry_points={
+        "console_scripts": ["mediafire-dl=mediafire_dl:main"],
+    },
+)


### PR DESCRIPTION
This makes this project a simple pip package so it can be uploaded to [pypi](https://pypi.org/) or directly installed from the git repo. This also adds a simple argument parser which provides a nice help message.