### PR TITLE
add: Add default parameter on download

### DIFF
--- a/mediafire_dl.py
+++ b/mediafire_dl.py
@@ -20,7 +20,7 @@ def extractDownloadLink(contents):
         if m:
             return m.groups()[0]
 
-def download(url, output, quiet):
+def download(url, output=None, quiet=False):
     url_origin = url
     sess = requests.session()
     sess.headers = {


### PR DESCRIPTION
Now we can simply download using only given urls into download function

```python
import mediafire_dl

mediafire_dl.download("https://mediafire.com/xx/xx/file.zip")
```

